### PR TITLE
Added control points support to sketcher

### DIFF
--- a/src/Mod/Sketcher/App/Constraint.h
+++ b/src/Mod/Sketcher/App/Constraint.h
@@ -58,7 +58,7 @@ enum InternalAlignmentType {
 };
 
 /// define if you want to use the end or start point
-enum PointPos { none, start, end, mid };
+enum PointPos { none, start, end, mid, control1, control2 };
 
 class SketcherExport Constraint : public Base::Persistence
 {

--- a/src/Mod/Sketcher/App/Sketch.cpp
+++ b/src/Mod/Sketcher/App/Sketch.cpp
@@ -2489,6 +2489,10 @@ int Sketch::getPointId(int geoId, PointPos pos) const
         return Geoms[geoId].endPointId;
     case mid:
         return Geoms[geoId].midPointId;
+    case control1:
+        return Geoms[geoId].controlPoint1Id;
+    case control2:
+        return Geoms[geoId].controlPoint2Id;
     case none:
         break;
     }

--- a/src/Mod/Sketcher/App/Sketch.h
+++ b/src/Mod/Sketcher/App/Sketch.h
@@ -208,7 +208,8 @@ protected:
     /// container element to store and work with the geometric elements of this sketch
     struct GeoDef {
         GeoDef() : geo(0),type(None),external(false),index(-1),
-                   startPointId(-1),midPointId(-1),endPointId(-1) {}
+                   startPointId(-1),midPointId(-1),endPointId(-1),
+                   controlPoint1Id(-1),controlPoint2Id(-1)  {}
         Part::Geometry  * geo;             // pointer to the geometry
         GeoType           type;            // type of the geometry
         bool              external;        // flag for external geometries
@@ -216,6 +217,8 @@ protected:
         int               startPointId;    // index in Points of the start point of this geometry
         int               midPointId;      // index in Points of the start point of this geometry
         int               endPointId;      // index in Points of the end point of this geometry
+        int               controlPoint1Id; // index in Points of control point 1 (e.g. ellipse focus)
+        int               controlPoint2Id; // index in Points of control point 2 (for future)
     };
 
     std::vector<GeoDef> Geoms;

--- a/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp
+++ b/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp
@@ -613,6 +613,8 @@ void CmdSketcherSelectElementsAssociatedWithConstraints::activated(int iMsg)
                         case Sketcher::start:
                         case Sketcher::end:
                         case Sketcher::mid: 
+                        case Sketcher::control1:
+                        case Sketcher::control2:
                             int vertex = Obj->getVertexIndexGeoPos(vals[ConstrId]->First,vals[ConstrId]->FirstPos);
                             if(vertex>-1)
                                 ss << "Vertex" <<  vertex + 1;
@@ -634,6 +636,8 @@ void CmdSketcherSelectElementsAssociatedWithConstraints::activated(int iMsg)
                         case Sketcher::start:
                         case Sketcher::end:
                         case Sketcher::mid: 
+                        case Sketcher::control1:
+                        case Sketcher::control2:
                             int vertex = Obj->getVertexIndexGeoPos(vals[ConstrId]->Second,vals[ConstrId]->SecondPos);
                             if(vertex>-1)
                                 ss << "Vertex" << vertex + 1;
@@ -655,6 +659,8 @@ void CmdSketcherSelectElementsAssociatedWithConstraints::activated(int iMsg)
                         case Sketcher::start:
                         case Sketcher::end:
                         case Sketcher::mid: 
+                        case Sketcher::control1:
+                        case Sketcher::control2:
                             int vertex = Obj->getVertexIndexGeoPos(vals[ConstrId]->Third,vals[ConstrId]->ThirdPos);
                             if(vertex>-1)
                                 ss << "Vertex" <<  vertex + 1;


### PR DESCRIPTION
Modified the sketcher to support 5 points per object (was: 3). This is
the first attempt that looks like working, but I may have missed
something.

I have not touched geometry element list yet.
