### PR TITLE
ParaObject: Enable to return directly downcasted handles

### DIFF
--- a/src/Mod/ConstraintSolver/App/G2D/ConstraintCurvePosPyImp.cpp
+++ b/src/Mod/ConstraintSolver/App/G2D/ConstraintCurvePosPyImp.cpp
@@ -19,7 +19,7 @@ PyObject *ConstraintCurvePosPy::PyMake(struct _typeobject *, PyObject* args, PyO
             PyErr_SetString(PyExc_TypeError, "Only keyword arguments are supported");
             throw Py::Exception();
         }
-        HConstraintCurvePos p = (new ConstraintCurvePos)->self().downcast<ConstraintCurvePos>();
+        HConstraintCurvePos p = (new ConstraintCurvePos)->getHandle<ConstraintCurvePos>();
         if (kwd && kwd != Py_None)
             p->initFromDict(Py::Dict(kwd));
         return p.getHandledObject();

--- a/src/Mod/ConstraintSolver/App/G2D/ConstraintDistancePyImp.cpp
+++ b/src/Mod/ConstraintSolver/App/G2D/ConstraintDistancePyImp.cpp
@@ -19,7 +19,7 @@ PyObject *ConstraintDistancePy::PyMake(struct _typeobject *, PyObject* args, PyO
             PyErr_SetString(PyExc_TypeError, "Only keyword arguments are supported");
             throw Py::Exception();
         }
-        HConstraintDistance p = (new ConstraintDistance)->self().downcast<ConstraintDistance>();
+        HConstraintDistance p = (new ConstraintDistance)->getHandle<ConstraintDistance>();
         if (kwd && kwd != Py_None)
             p->initFromDict(Py::Dict(kwd));
         return p.getHandledObject();

--- a/src/Mod/ConstraintSolver/App/G2D/ConstraintPointSymmetryPyImp.cpp
+++ b/src/Mod/ConstraintSolver/App/G2D/ConstraintPointSymmetryPyImp.cpp
@@ -19,7 +19,7 @@ PyObject *ConstraintPointSymmetryPy::PyMake(struct _typeobject *, PyObject* args
             PyErr_SetString(PyExc_TypeError, "Only keyword arguments are supported");
             throw Py::Exception();
         }
-        HConstraintPointSymmetry p = (new ConstraintPointSymmetry)->self().downcast<ConstraintPointSymmetry>();
+        HConstraintPointSymmetry p = (new ConstraintPointSymmetry)->getHandle<ConstraintPointSymmetry>();
         if (kwd && kwd != Py_None)
             p->initFromDict(Py::Dict(kwd));
         return p.getHandledObject();

--- a/src/Mod/ConstraintSolver/App/G2D/ParaGeometry2D.cpp
+++ b/src/Mod/ConstraintSolver/App/G2D/ParaGeometry2D.cpp
@@ -22,5 +22,5 @@ PyObject* ParaGeometry2D::getPyObject()
 
 HParaObject FCS::G2D::ParaGeometry2D::toShape()
 {
-    return new ParaShapeBase(self().downcast<ParaGeometry>());
+    return new ParaShapeBase(getHandle<ParaGeometry>());
 }

--- a/src/Mod/ConstraintSolver/App/G2D/ParaPlacement.cpp
+++ b/src/Mod/ConstraintSolver/App/G2D/ParaPlacement.cpp
@@ -53,6 +53,6 @@ PyObject* ParaPlacement::getPyObject()
 
 std::vector<HConstraint> ParaPlacement::makeRuleConstraints()
 {
-    return {(new ConstraintPlacementRules)->self().downcast<Constraint>()};
+    return {(new ConstraintPlacementRules)->getHandle<Constraint>()};
 }
 

--- a/src/Mod/ConstraintSolver/App/G2D/ParaPointPyImp.cpp
+++ b/src/Mod/ConstraintSolver/App/G2D/ParaPointPyImp.cpp
@@ -19,7 +19,7 @@ PyObject *ParaPointPy::PyMake(struct _typeobject *, PyObject* args, PyObject* kw
     return pyTryCatch([&]()->Py::Object{
         {
             if (PyArg_ParseTuple(args, "")){
-                HParaPoint p = (new ParaPoint)->self().downcast<ParaPoint>();
+                HParaPoint p = (new ParaPoint)->getHandle<ParaPoint>();
                 if (kwd && kwd != Py_None)
                     p->initFromDict(Py::Dict(kwd));
                 return p.getHandledObject();
@@ -30,7 +30,7 @@ PyObject *ParaPointPy::PyMake(struct _typeobject *, PyObject* args, PyObject* kw
             PyObject* x;
             PyObject* y;
             if (PyArg_ParseTuple(args, "O!O!",&(ParameterRefPy::Type), &x, &(ParameterRefPy::Type), &y)){
-                HParaPoint p = (new ParaPoint(*HParameterRef(x,false), *HParameterRef(y,false)))->self().downcast<ParaPoint>();
+                HParaPoint p = (new ParaPoint(*HParameterRef(x,false), *HParameterRef(y,false)))->getHandle<ParaPoint>();
                 if (kwd && kwd != Py_None)
                     p->initFromDict(Py::Dict(kwd));
                 return p.getHandledObject();

--- a/src/Mod/ConstraintSolver/App/G2D/ParaShape.cpp
+++ b/src/Mod/ConstraintSolver/App/G2D/ParaShape.cpp
@@ -72,7 +72,7 @@ HParaObject FCS::G2D::ParaShapeBase::copy() const
 HParaShapeBase G2D::ParaShapeBase::getSubShape(const ParaGeometry& subshape)
 {
     HParaShapeBase ret = new ParaShapeBase();
-    ret->_tshape = const_cast<ParaGeometry&>(subshape).self();
+    ret->_tshape = const_cast<ParaGeometry&>(subshape).getHandle();
     this->placement->lock();
     ret->placement = this->placement;
     ret->placement->lock();

--- a/src/Mod/ConstraintSolver/App/G2D/ParaShapePyImp.cpp
+++ b/src/Mod/ConstraintSolver/App/G2D/ParaShapePyImp.cpp
@@ -15,7 +15,7 @@ PyObject *ParaShapePy::PyMake(struct _typeobject *, PyObject* args, PyObject* kw
     return pyTryCatch([&]()->Py::Object{
         {
             if (PyArg_ParseTuple(args, "")){
-                HParaShapeBase p = (new ParaShapeBase)->self().downcast<ParaShapeBase>();
+                HParaShapeBase p = (new ParaShapeBase)->getHandle<ParaShapeBase>();
                 if (kwd && kwd != Py_None)
                     p->initFromDict(Py::Dict(kwd));
                 return p.getHandledObject();

--- a/src/Mod/ConstraintSolver/App/G2D/ParaTransform.cpp
+++ b/src/Mod/ConstraintSolver/App/G2D/ParaTransform.cpp
@@ -134,7 +134,7 @@ void ParaTransform::initFromDict(Py::Dict dict)
         Py::Tuple tup(it);
         std::string key = Py::String(tup[0]);
         Py::Object val = tup[1];
-        FCS::setAttr(self().getHandledObject(), key, val);
+        FCS::setAttr(getHandle().getHandledObject(), key, val);
     }
 }
 

--- a/src/Mod/ConstraintSolver/App/G2D/ParaVectorPyImp.cpp
+++ b/src/Mod/ConstraintSolver/App/G2D/ParaVectorPyImp.cpp
@@ -16,7 +16,7 @@ PyObject *ParaVectorPy::PyMake(struct _typeobject *, PyObject* args, PyObject* k
 
         {
             if (PyArg_ParseTuple(args, "")){
-                HParaVector p = (new ParaVector)->self().downcast<ParaVector>();
+                HParaVector p = (new ParaVector)->getHandle<ParaVector>();
                 if (kwd && kwd != Py_None)
                     p->initFromDict(Py::Dict(kwd));
                 return p.getHandledObject();
@@ -27,7 +27,7 @@ PyObject *ParaVectorPy::PyMake(struct _typeobject *, PyObject* args, PyObject* k
             PyObject* x;
             PyObject* y;
             if (PyArg_ParseTuple(args, "O!O!",&(ParameterRefPy::Type), &x, &(ParameterRefPy::Type), &y)){
-                HParaVector p = (new ParaVector(*HParameterRef(x,false), *HParameterRef(y,false)))->self().downcast<ParaVector>();
+                HParaVector p = (new ParaVector(*HParameterRef(x,false), *HParameterRef(y,false)))->getHandle<ParaVector>();
                 if (kwd && kwd != Py_None)
                     p->initFromDict(Py::Dict(kwd));
                 return p.getHandledObject();

--- a/src/Mod/ConstraintSolver/App/ParaObject.cpp
+++ b/src/Mod/ConstraintSolver/App/ParaObject.cpp
@@ -27,11 +27,6 @@ PyObject* ParaObject::getPyObject()
     }
 }
 
-HParaObject ParaObject::self()
-{
-    return HParaObject(getPyObject(), true);
-}
-
 std::string ParaObject::repr() const
 {
     std::stringstream ss;
@@ -284,7 +279,7 @@ void ParaObject::setAttr(std::string attrname, Py::Object val)
         }
     };
     std::stringstream ss;
-    ss << self().getHandledObject().repr().as_std_string() << " has no attribute "
+    ss << getHandle().getHandledObject().repr().as_std_string() << " has no attribute "
        << attrname;
     throw Py::AttributeError(ss.str());
 }
@@ -320,7 +315,7 @@ void ParaObject::initFromDict(Py::Dict dict)
         Py::Object val = tup[1];
         if (key == "store")
             continue;//process it last
-        FCS::setAttr(self().getHandledObject(), key, val);
+        FCS::setAttr(getHandle().getHandledObject(), key, val);
     }
     if (dict.hasKey("store")){
         HParameterStore store (dict["store"]);

--- a/src/Mod/ConstraintSolver/App/ParaObject.h
+++ b/src/Mod/ConstraintSolver/App/ParaObject.h
@@ -88,9 +88,15 @@ public://data members
 
 public: //methods
     virtual PyObject* getPyObject() override;
-    HParaObject self();
+    
     virtual std::string repr() const;
-
+    
+    template <  typename NewTypeT = ParaObject,
+                typename = typename std::enable_if<
+                    std::is_base_of<ParaObject, typename std::decay<NewTypeT>::type>::value
+             >::type
+    >
+    UnsafePyHandle<NewTypeT> getHandle();
     /**
      * @brief update: updates list of parameters. Must call after redirecting prarmeters.
      * It ignores touched state of this object, but calls update on child objects only if the child is touched.
@@ -141,6 +147,15 @@ protected: //methods
 public: //friends
     friend class ParaObjectPy;
 };
+
+template <  typename NewTypeT,
+            typename 
+>
+UnsafePyHandle<NewTypeT> ParaObject::getHandle() 
+{
+    return UnsafePyHandle<NewTypeT>(getPyObject(), true);
+}
+
 
 } //namespace
 


### PR DESCRIPTION
========================================================

By morphing self() into getHandle<T>() with T defaulting to HParaObject.

getHandle() returns a HParaObject handle to the object.

getHandle<Constraint>() returns a HConstraint handle to the object.

Type checking is performed, so that only handles to Types deriving from ParaObject are allowed.
